### PR TITLE
Updated to better match current usage

### DIFF
--- a/xkcdBOT.pl
+++ b/xkcdBOT.pl
@@ -312,10 +312,10 @@ $text = <<END;
 }}
 
 ==Explanation==
-{{incomplete|Created by a BOT - Please change this comment when editing this page. Do NOT delete this tag too soon.}}
+{{incomplete|This page was created recently. Don't remove this notice too soon.}}
 
 ==Transcript==
-{{incomplete transcript|Do NOT delete this tag too soon.}}
+{{incomplete transcript|Don't remove this notice too soon.}}
 
 {{comic discussion}}
 END


### PR DESCRIPTION
Shortened the incomplete message because of how it's being used. Removed "Please edit this when editing the page" because the template text is almost never changed nowadays, the template is simply removed altogether after a few days. The new version is clearer.

Also, it works better with the refreshed {{incomplete}} and {{incomplete transcript}} templates, which have different text than before as they've been changed recently.